### PR TITLE
Add Docker image and release pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+.context
+dist
+helmfmt
+*.md
+!README.md
+LICENSE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   # Test and build snapshot for PRs
@@ -43,6 +44,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ steps.version.outputs.version }}
+
+      - name: Build Docker image (validate, no push)
+        run: |
+          docker build \
+            --build-arg VERSION=${{ steps.version.outputs.version }} \
+            -t helmfmt:${{ steps.version.outputs.version }} \
+            .
 
   # Create tag and release when PR is merged to main
   release:
@@ -85,3 +93,42 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ steps.version.outputs.version }}
+
+      - name: Set up QEMU
+        if: steps.version.outputs.skip != 'true'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: steps.version.outputs.skip != 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: steps.version.outputs.skip != 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        if: steps.version.outputs.skip != 'true'
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/helmfmt
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        if: steps.version.outputs.skip != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.25-alpine AS build
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+ARG VERSION=dev
+RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.Version=${VERSION}" -o /helmfmt .
+
+FROM scratch
+COPY --from=build /helmfmt /usr/local/bin/helmfmt
+
+WORKDIR /work
+ENTRYPOINT ["/usr/local/bin/helmfmt"]

--- a/README.md
+++ b/README.md
@@ -136,6 +136,34 @@ Then add it to `PATH` via:
 sudo install ./helmfmt /usr/local/bin/
 ```
 
+### Docker
+
+A container image is published to the GitHub Container Registry on every release:
+
+```bash
+docker pull ghcr.io/digitalstudium/helmfmt:latest
+```
+
+Mount your chart into the container's working directory (`/work`) and pass paths relative to it:
+
+```bash
+# Format a whole chart in place
+docker run --rm -v "$PWD:/work" ghcr.io/digitalstudium/helmfmt:latest ./mychart
+
+# Check formatting in CI (exits non-zero if unformatted)
+docker run --rm -v "$PWD:/work" ghcr.io/digitalstudium/helmfmt:latest --check ./mychart
+
+# Format specific files
+docker run --rm -v "$PWD:/work" ghcr.io/digitalstudium/helmfmt:latest \
+  --files templates/deployment.yaml templates/service.yaml
+```
+
+Images are built for both `linux/amd64` and `linux/arm64`. You can also build it yourself:
+
+```bash
+docker build -t helmfmt .
+```
+
 ---
 
 ## Usage


### PR DESCRIPTION
Publish a scratch-based container image to GHCR on release, validate the build on PRs with a native docker build, and document Docker usage in the README. 

closes #15 